### PR TITLE
Fix background color to fit Node screenshots

### DIFF
--- a/resources/theme/css/theme_overrides.css
+++ b/resources/theme/css/theme_overrides.css
@@ -67,7 +67,7 @@
    }
    a.reference.internal {
       color: #9f61b9 !important;
-      background-color: #1e1e1e !important;
+      background-color: #1d1d1d !important;
    }
    a.reference.internal.current {
       color: rgb(200, 200, 200) !important;


### PR DESCRIPTION
This corrects the discrepancy between the background color of the node modules screenshots and the documentation website.

<img width="1330" height="850" alt="image" src="https://github.com/user-attachments/assets/a7f57aba-cb4d-4326-9e84-6b584377f660" />
